### PR TITLE
Added documentation and integrated the pictures in the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 lang.dot
 compiled/
+/doc/
+/lang-slide/doc/

--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
 
 (define collection 'multi)
+(define build-deps '("scribble-lib" "racket-doc" "pict-doc"))
 (define deps '("base" "draw-lib" "gui-lib" "scheme-lib" "slideshow-lib" "unstable-lib"))

--- a/info.rkt
+++ b/info.rkt
@@ -3,3 +3,5 @@
 (define collection 'multi)
 (define build-deps '("scribble-lib" "racket-doc" "pict-doc"))
 (define deps '("base" "draw-lib" "gui-lib" "scheme-lib" "slideshow-lib" "unstable-lib"))
+(define pkg-desc "A picture showing all the languages used to implement Racket.")
+(define version "1.0")

--- a/lang-slide/draw-plain.rkt
+++ b/lang-slide/draw-plain.rkt
@@ -1,8 +1,9 @@
-#lang scheme/gui
+#lang racket ;scheme/gui
 (provide lang-pict string->color)
 
 (require scheme/runtime-path
-         slideshow)
+         slideshow/pict
+         racket/draw)
 
 (define-runtime-path lang.plain "lang.plain")
 

--- a/lang-slide/info.rkt
+++ b/lang-slide/info.rkt
@@ -1,0 +1,5 @@
+#lang info
+(define build-deps '("scribble-lib" "racket-doc"))
+(define scribblings '(("scribblings/lang-slide.scrbl" ())))
+(define pkg-desc "A picture showing all the languages used to implement Racket.")
+(define version "1.0")

--- a/lang-slide/info.rkt
+++ b/lang-slide/info.rkt
@@ -1,5 +1,2 @@
 #lang info
-(define build-deps '("scribble-lib" "racket-doc"))
 (define scribblings '(("scribblings/lang-slide.scrbl" ())))
-(define pkg-desc "A picture showing all the languages used to implement Racket.")
-(define version "1.0")

--- a/lang-slide/main.rkt
+++ b/lang-slide/main.rkt
@@ -1,110 +1,29 @@
 #lang scheme
-(provide langs-pict
+
+(provide (rename-out [langs-pict1 langs-pict])
          langs-in-tree
          langs-with-colors)
+(require "pictures.rkt")
 (require "draw-plain.ss"
          "orig-colors.rkt"
-         racket/draw slideshow/code
+         racket/draw
+         slideshow/code
          scheme/runtime-path
-         slideshow)
-(define-runtime-path lang-colors.rktd "lang-colors.rktd")
+         slideshow/pict
+         slideshow/base
+         "pictures.rkt")
 
-(define (color->name c)
-  (define-values (r g b) (split-out-color c))
-  (cond
-    [(and (equal? r 0) (equal? g 0) (equal? b 0))
-     'black]
-    [else
-     (define res 
-       (for/or ([(k v) (in-hash orig-colors)])
-         (for/or ([c (in-list v)])
-           (define rgb (cond
-                         [(string? c)
-                          (define clr (send the-color-database find-color c))
-                          (list (send clr red) (send clr green) (send clr blue))]
-                         [else 
-                          c]))
-           (and (equal? rgb (list r g b))
-                k))))
-     (unless res (error 'color->name "unable to find color name for ~s" c))
-     res]))
-
-(define (color-name->index c)
-  (case c
-    [(blue) 0]
-    [(red) 1]
-    [(orange) 1.5]
-    [(green) 2]
-    [(gray) 3]
-    [(pink) 4]
-    [(cyan) 5]
-    [(purple) 5.5]
-    [(yellow) 7]
-    [(brown) 8]
-    [(black) 100]
-    [else (error 'color-name->index "unk ~s" c)]))
-
-(define (split-out-color c)
-  (values
-   (string->number (substring c 1 3) 16)
-   (string->number (substring c 3 5) 16)
-   (string->number (substring c 5 7) 16)))
-
-(define (color<=? c1 c2)
-  (let ([n1 (color->name c1)]
-        [n2 (color->name c2)])
-    (cond
-      [(equal? n1 n2)
-       (string<=? c1 c2)]
-      [else
-       (<= (color-name->index n1)
-           (color-name->index n2))])))
-
-(define lang-colors 
-  (sort (call-with-input-file lang-colors.rktd read)
-        color<=?
-        #:key cadr))
-
-(define-values (black-langs colored-langs)
-  (partition (λ (x) (equal? (cadr x) "#000000")) lang-colors))
-
-(define (line->color cl)
-  (parameterize ([current-font-size 14])
-    (hc-append 6
-               (colorize (filled-ellipse 14 14)
-                         (string->color (cadr cl)))
-               (text (car cl) (current-code-font) (current-font-size)))))
-
-(define (langs-pict color? 
-                    #:fit? [fit? #f]
-                    #:picts [p (if (pict? color?) (list color?) (list))])
-  (define colors (langs-with-colors))
-  (define len (length colors))
-  (define start (ceiling (/ len 2)))
-  (define-values (one two) (split-at colors start))
-  (define all
-    (ht-append
-     0
-     (langs-in-tree color?)
-     (apply vc-append 40 
-            (ht-append 20
-                       ((if color? values ghost)
-                        (apply vl-append 2 one))
-                       ((if color? values ghost)
-                        (apply vl-append 2 two)))
-            p)))
-  (if fit?
-      (scale all (min 1 
-                      (/ client-w (pict-width all))
-                      (/ client-h (pict-height all))))
-      all))
-
-(define (langs-with-colors)
-  (map line->color
-       (append colored-langs (list (list "everything else" "#000000")))))
-
-(define (langs-in-tree color?)
-  (inset (lang-pict 550 color?) 14 10 -10 10))
+(define (langs-pict1 color? 
+                     #:fit? [fit? #f]
+                     #:picts [p (if (pict? color?) (list color?) (list))])
+  (langs-pict color?
+              #:fit (λ (all)
+                      (if fit?
+                          (scale all (min 1 
+                                          (/ client-w (pict-width all))
+                                          (/ client-h (pict-height all))))
+                          all))
+              #:picts p))
 
 (module+ main
   (slide (langs-pict #f))

--- a/lang-slide/pictures.rkt
+++ b/lang-slide/pictures.rkt
@@ -1,0 +1,107 @@
+#lang racket
+
+(require "draw-plain.ss"
+         "orig-colors.rkt"
+         racket/draw
+         slideshow/code-pict
+         racket/runtime-path
+         slideshow/pict)
+
+(provide langs-pict
+         langs-in-tree
+         langs-with-colors)
+
+(define-runtime-path lang-colors.rktd "lang-colors.rktd")
+
+(define (color->name c)
+  (define-values (r g b) (split-out-color c))
+  (cond
+    [(and (equal? r 0) (equal? g 0) (equal? b 0))
+     'black]
+    [else
+     (define res 
+       (for/or ([(k v) (in-hash orig-colors)])
+         (for/or ([c (in-list v)])
+           (define rgb (cond
+                         [(string? c)
+                          (define clr (send the-color-database find-color c))
+                          (list (send clr red) (send clr green) (send clr blue))]
+                         [else 
+                          c]))
+           (and (equal? rgb (list r g b))
+                k))))
+     (unless res (error 'color->name "unable to find color name for ~s" c))
+     res]))
+
+(define (color-name->index c)
+  (case c
+    [(blue) 0]
+    [(red) 1]
+    [(orange) 1.5]
+    [(green) 2]
+    [(gray) 3]
+    [(pink) 4]
+    [(cyan) 5]
+    [(purple) 5.5]
+    [(yellow) 7]
+    [(brown) 8]
+    [(black) 100]
+    [else (error 'color-name->index "unk ~s" c)]))
+
+(define (split-out-color c)
+  (values
+   (string->number (substring c 1 3) 16)
+   (string->number (substring c 3 5) 16)
+   (string->number (substring c 5 7) 16)))
+
+(define (color<=? c1 c2)
+  (let ([n1 (color->name c1)]
+        [n2 (color->name c2)])
+    (cond
+      [(equal? n1 n2)
+       (string<=? c1 c2)]
+      [else
+       (<= (color-name->index n1)
+           (color-name->index n2))])))
+
+(define lang-colors 
+  (sort (call-with-input-file lang-colors.rktd read)
+        color<=?
+        #:key cadr))
+
+(define-values (black-langs colored-langs)
+  (partition (λ (x) (equal? (cadr x) "#000000")) lang-colors))
+
+(define (line->color cl)
+  (let ([font-size 14])
+    (hc-append 6
+               (colorize (filled-ellipse 14 14)
+                         (string->color (cadr cl)))
+               (text (car cl) (current-code-font) font-size))))
+
+(define (langs-pict color? 
+                    #:fit [fit (λ (x) x)]
+                    #:picts [p (if (pict? color?) (list color?) (list))])
+  (define colors (langs-with-colors))
+  (define len (length colors))
+  (define start (ceiling (/ len 2)))
+  (define-values (one two) (split-at colors start))
+  (define all
+    (ht-append
+     0
+     (langs-in-tree color?)
+     (apply vc-append 40 
+            (ht-append 20
+                       ((if color? values ghost)
+                        (apply vl-append 2 one))
+                       ((if color? values ghost)
+                        (apply vl-append 2 two)))
+            p)))
+  (fit all))
+
+(define (langs-with-colors)
+  (map line->color
+       (append colored-langs (list (list "everything else" "#000000")))))
+
+(define (langs-in-tree color?)
+  (inset (lang-pict 550 color?) 14 10 -10 10))

--- a/lang-slide/scribblings/lang-slide.scrbl
+++ b/lang-slide/scribblings/lang-slide.scrbl
@@ -20,6 +20,8 @@ And here is the languages they use:
 
 @section{Pictures}
 
+@defmodule[lang-slide/pictures]
+
 @racketmodname{lang-slide/pictures} provides several 
 @racketmodname[pict]s, with some options.
 

--- a/lang-slide/scribblings/lang-slide.scrbl
+++ b/lang-slide/scribblings/lang-slide.scrbl
@@ -14,7 +14,7 @@ Here is a bird's eye view of the modules implementing racket:
 
 @(langs-pict #f)
 
-And here is the languages they use:
+And here are the languages they use:
 
 @(langs-pict #t)
 

--- a/lang-slide/scribblings/lang-slide.scrbl
+++ b/lang-slide/scribblings/lang-slide.scrbl
@@ -1,0 +1,18 @@
+#lang scribble/manual
+@require[@for-label[lang-slide
+                    racket/base]
+         lang-slide/pictures
+         ;slideshow/pict
+         ]
+
+@title{A picture showing all the languages used to implement Racket.}
+
+Source code: @url{https://github.com/samth/lang-slide}
+
+Here is a bird's eye view of the modules implementing racket:
+
+@(langs-pict #f)
+
+And here is the languages they use:
+
+@(langs-pict #t)

--- a/lang-slide/scribblings/lang-slide.scrbl
+++ b/lang-slide/scribblings/lang-slide.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/manual
-@require[@for-label[lang-slide
+@require[@for-label[lang-slide/pictures
                     racket/base]
          lang-slide/pictures
          ;slideshow/pict
@@ -20,8 +20,20 @@ And here is the languages they use:
 
 @section{Pictures}
 
-@tt{main.rkt} provides several @racketmodname[pict]s,
-with some options.
+@racketmodname{lang-slide/pictures} provides several 
+@racketmodname[pict]s, with some options.
+
+@defproc[(langs-pict [color? any]
+          [#:fit fit (-> pict? pict?)]
+          [#:picts p (listof pict-convertible?)])
+         pict?]{
+}
+@defproc[(langs-in-tree [color? boolean?])
+         pict?]{
+}
+@defproc[(langs-with-colors)
+         (listof pict?)]{
+}
 
 @section{Slides}
 

--- a/lang-slide/scribblings/lang-slide.scrbl
+++ b/lang-slide/scribblings/lang-slide.scrbl
@@ -6,6 +6,7 @@
          ]
 
 @title{A picture showing all the languages used to implement Racket.}
+@author{Sam Tobin-Hochstadt (Originally by Robby Findler)}
 
 Source code: @url{https://github.com/samth/lang-slide}
 
@@ -16,3 +17,29 @@ Here is a bird's eye view of the modules implementing racket:
 And here is the languages they use:
 
 @(langs-pict #t)
+
+@section{Pictures}
+
+@tt{main.rkt} provides several @racketmodname[pict]s,
+with some options.
+
+@section{Slides}
+
+To show a slide that demos the pict, run
+@tt{main.rkt} on the command-lide, or use
+
+@racketblock[
+ @#,hash-lang[] @#,racketmodname[racket]
+ (require (submod lang-slide/main main))]
+
+@tt{hudak-quote.rkt} has a slideshow slide that uses
+the picture along with a quote from Paul Hudak.
+
+@section{PNG}
+
+@tt{mk-img.rkt} generates a PNG of the image.
+
+@section{Regenerating the data}
+
+@tt{find.rkt} regenerates @tt{lang.plain} and
+@tt{lang-colors.rktd} automatically when run.


### PR DESCRIPTION
I added documentation for this package and integrated the pictures in the docs so that they can be viewed more easily, instead of having to download the package and manually find and run `main.rkt`.

Since `(require lang-slide/main)` initializes `slideshow`, which looks at the command-line arguments, inserting that `require` in the docs made the package installation fail because `slideshow` was unhappy with `raco`'s command-line arguments, so I moved the pictures definitions to `(require lang-slide/pictures)`, which does not depend on `slideshow`, and kept the original exports in `main.rkt` for backwards compatibility.

Also, `draw-plain.rkt` was using `racket/gui`, so when it was required at two different meta-levels, the gui lib would complain about being instantiated twice.

There's a slight quirk in the docs: the identifiers `langs-pict`, `langs-in-tree` and `langs-with-colors` aren't correctly linked, and scribble says `WARNING: no declared exporting libraries for definition in: langs-pict` etc. I haven't had time to investigate that, sorry. I suspect this is due to `(define collection 'multi)` in info.rkt, but don't know how to fix that.
